### PR TITLE
Added the ability to export and import Stock By Attributes data for item...

### DIFF
--- a/admin/easypopulate_4.php
+++ b/admin/easypopulate_4.php
@@ -388,6 +388,9 @@ if (!$error && isset($_REQUEST["delete"]) && $_REQUEST["delete"]!=basename($_SER
     <br><b>Attribute Export/Import Options</b><br>
     <a href="easypopulate_4.php?export=attrib_basic"><b>Basic Products Attributes</b> (basic single-line)</a><br /> 
     <a href="easypopulate_4.php?export=attrib_detailed"><b>Detailed Products Attributes</b> (detailed multi-line)</a><br />
+<?php if (ep_4_SBA1Exists() == true) { ?>
+    <a href="easypopulate_4.php?export=SBA_detailed"><b>Detailed Stock By Attributes Data</b> (detailed multi-line)</a><br />
+<?php } ?>
     
     <br>DIAGNOSTIC EXPORTS - Note: NOT FOR IMPORTING ATTRIBUTES!<br>
     <a href="easypopulate_4.php?export=options"><b>Attribute Options Names</b></a><br />

--- a/admin/easypopulate_4_export.php
+++ b/admin/easypopulate_4_export.php
@@ -90,6 +90,9 @@ switch ($ep_dltype) { // chadd - changed to use $EXPORT_FILE
 	case 'attrib_detailed':
 	$EXPORT_FILE = 'Attrib-Detailed-EP';
 	break;
+	case 'SBA_detailed'; // mc12345678 - added 07-18-2013 to support Stock By Attributes
+	$EXPORT_FILE = 'SBA-Detailed-EP';
+	break;
 	case 'attrib_basic':
 	$EXPORT_FILE = 'Attrib-Basic-EP';
 	break;
@@ -138,6 +141,7 @@ if ($ep_dltype == 'attrib_basic') { // special case 'attrib_basic'
 			// collect the products_options_values_name
 			if ($active_language_id <> $row['v_language_id']) {
 				$l_id = $row['v_language_id'];
+				$active_row['v_products_options_type'] = $row['v_products_options_type'];
 				$active_row['v_products_options_name_'.$l_id] = $row['v_products_options_name'];
 				$active_row['v_products_options_values_name_'.$l_id] = $row['v_products_options_values_name'];
 				$active_language_id = $row['v_language_id'];
@@ -145,6 +149,7 @@ if ($ep_dltype == 'attrib_basic') { // special case 'attrib_basic'
 				$l_id = $row['v_language_id'];
 				$active_row['v_products_options_name_'.$l_id] = $row['v_products_options_name'];
 				$active_row['v_products_options_values_name_'.$l_id] .= ",".$row['v_products_options_values_name'];
+				$active_row['v_products_options_type'] = $row['v_products_options_type'];
 			}
 			continue; // loop - for more products_options_values_name on same v_products_id/v_options_id combo
 		} else { // same product, new attribute - only executes once on new option
@@ -168,6 +173,7 @@ if ($ep_dltype == 'attrib_basic') { // special case 'attrib_basic'
 			$l_id = $row['v_language_id'];
 			$active_row['v_products_options_name_'.$l_id] = $row['v_products_options_name'];
 			$active_row['v_products_options_values_name_'.$l_id] = $row['v_products_options_values_name'];
+			$active_row['v_products_options_type'] = $row['v_products_options_type'];
 			continue; // loop - for more products_options_values_name on same v_products_id/v_options_id combo
 		}
 	} else { // new combo or different product or first time through while-loop
@@ -221,6 +227,23 @@ if ($ep_dltype == 'attrib_basic') { // special case 'attrib_basic'
 			}				
 		}
 
+		else 
+			if ($ep_dltype == 'SBA_detailed') {
+				if (isset($filelayout['v_products_attributes_filename'])) /* Believe this should be an SBA filename; however, need to look at the filename assignment function to see how this works.  */{ 
+					$sql2 = 'SELECT * FROM '.TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD.' WHERE products_attributes_id = '.$row['v_products_attributes_id'].' LIMIT 1';
+					$result2 = ep_4_query($sql2);
+					$row2 = mysql_fetch_array($result2);
+					if (mysql_num_rows($result2)) {
+						$row['v_products_attributes_filename'] = $row2['products_attributes_filename']; 
+						$row['v_products_attributes_maxdays'] = $row2['products_attributes_maxdays']; 
+						$row['v_products_attributes_maxcount'] = $row2['products_attributes_maxcount']; 
+					} else {
+						$row['v_products_attributes_filename'] = '';
+						$row['v_products_attributes_maxdays'] = '';
+						$row['v_products_attributes_maxcount'] = '';
+					}
+				}				
+			}
 		// Products Image
 		if (isset($filelayout['v_products_image'])) { 
 			$products_image = (($row['v_products_image'] == PRODUCTS_IMAGE_NO_IMAGE) ? '' : $row['v_products_image']);

--- a/admin/includes/functions/extra_functions/easypopulate_4_functions.php
+++ b/admin/includes/functions/extra_functions/easypopulate_4_functions.php
@@ -51,6 +51,72 @@ function ep_4_get_languages() {
 	return $ep_languages_array;
 }
 
+function ep_4_SBA1Exists () {
+	// The current thought is to have one of these Exists files for each version of SBA to consider; however, they also all could fall under one SBA_Exists check provided some return is made and a comparison done on the other end about what was returned.  
+	//Check to see if any version of Stock with attributes is installed (If so, and properly programmed, there should be a define for the table associated with the stock.  There may be more than one, and if so, they should all be verified for the particular SBA.
+	if (defined('TABLE_PRODUCTS_WITH_ATTRIBUTES_STOCK')) {
+		//Now that have identified that the table (applicable to mc12345678's store, has been identified as in existence, now need to look at the setup of the table (Number of columns and if each column identified below is in the table, or conversely if the table's column matches the list below.
+		//Columns in table: stock_id, products_id, stock_attributes, quantity, and sort.
+//		echo 'In<br />';
+//		$colsarray = $db->Execute('SHOW COLUMNS FROM ' . TABLE_PRODUCTS_WITH_ATTRIBUTES_STOCK);
+		$colsarray = ep_4_query('SHOW COLUMNS FROM ' . TABLE_PRODUCTS_WITH_ATTRIBUTES_STOCK);
+//		echo 'After execute<br />';
+		$numCols = mysql_num_rows($colsarray);
+		if ($numCols == 5) {
+			while ($row = mysql_fetch_array($colsarray)){
+				switch ($row['Field']) {
+					case 'stock_id':
+						break;
+					case 'products_id':
+						break;
+					case 'stock_attributes':
+						break;
+					case 'quantity':
+						break;
+					case 'sort':
+						break;
+					default:
+						return false;
+						break;
+						
+				}
+//				print_r($row);
+/*				echo '4<br />';
+				if ($row['Field'] == 'stock_id') {
+					echo ' true <br />';
+				} else {
+					echo ' false <br />';
+				}
+				echo '3<br />'; */
+			}
+			return true;
+		} else {
+			return false;
+		}
+//		$returnedcols = mysql_fetch_array($colsarray);
+//		$colnames = array_keys($returnedcols);
+/*		echo 'Num Rows: ' . $numCols . '<br />';
+		if ($returnedcols['Field'] == 'stock_id') {
+			echo 'true <br />';
+		} else {
+			echo 'false <br />';
+		}
+		echo '3<br />';
+		echo $returnedcols . '111<br />';
+		print_r($returnedcols);
+		echo '3<br />'; */
+		
+/*		while ($row = mysql_fetch_array($colsarray)){
+			print_r($row);
+			echo '4<br />';
+		}
+		echo '4<br />';*/
+		//return true;
+	} else {
+		return false;
+	}
+}
+
 function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcode, $ep_supported_mods, $custom_fields) {
 	$filelayout = array();
 	switch($ep_dltype) {
@@ -487,6 +553,115 @@ function ep_4_set_filelayout($ep_dltype, &$filelayout_sql, $sql_filter, $langcod
 			a.options_values_id = v.products_options_values_id AND
 			o.language_id       = v.language_id ORDER BY a.products_id, a.options_id, v.language_id, v.products_options_values_id';
  		break;
+		
+	case 'SBA_detailed':
+		$filelayout[] =	'v_stock_id'; // stock id from SBA table
+		$filelayout[] =	'v_products_id';
+		$filelayout[] =	'v_stock_attributes'; 
+		$filelayout[] =	'v_products_model'; // product model from table PRODUCTS
+		$filelayout[] =	'v_quantity';
+		$filelayout[] =	'v_sort';
+		$filelayout[] =	'v_products_name'; // product model from table PRODUCTS
+		$filelayout[] =	'v_products_options_name'; // options name from table PRODUCTS_OPTIONS
+		$filelayout[] =	'v_products_options_values_name'; // options values name from table PRODUCTS_OPTIONS_VALUES
+		$filelayout[] =	'v_products_attributes_id';
+		$filelayout[] =	'v_products_options_type'; // 0-drop down, 1=text , 2=radio , 3=checkbox, 4=file, 5=read only 
+		$filelayout[] =	'v_options_id';
+		$filelayout[] =	'v_options_values_id';
+//		$filelayout[] =	'v_options_values_price';
+//		$filelayout[] =	'v_price_prefix';
+//		$filelayout[] =	'v_products_options_sort_order';
+//		$filelayout[] =	'v_product_attribute_is_free';
+//		$filelayout[] =	'v_products_attributes_weight';
+//		$filelayout[] =	'v_products_attributes_weight_prefix';
+//		$filelayout[] =	'v_attributes_display_only';
+//		$filelayout[] =	'v_attributes_default';
+//		$filelayout[] =	'v_attributes_discounted';
+//		$filelayout[] =	'v_attributes_image';
+//		$filelayout[] =	'v_attributes_price_base_included';
+//		$filelayout[] =	'v_attributes_price_onetime';
+//		$filelayout[] =	'v_attributes_price_factor';
+//		$filelayout[] =	'v_attributes_price_factor_offset';
+//		$filelayout[] =	'v_attributes_price_factor_onetime';
+//		$filelayout[] =	'v_attributes_price_factor_onetime_offset';
+//		$filelayout[] =	'v_attributes_qty_prices';
+//		$filelayout[] =	'v_attributes_qty_prices_onetime';
+//		$filelayout[] =	'v_attributes_price_words';
+//		$filelayout[] =	'v_attributes_price_words_free';
+//		$filelayout[] =	'v_attributes_price_letters';
+//		$filelayout[] =	'v_attributes_price_letters_free';
+//		$filelayout[] =	'v_attributes_required';
+// table TABLE_PRODUCTS_ATTRIBUTES_DOWNLOAD		
+//		$filelayout[] =	'v_products_SBA_filename';
+		$filelayout[] =	'v_products_attributes_filename';
+		$filelayout[] =	'v_products_attributes_maxdays';
+		$filelayout[] =	'v_products_attributes_maxcount';
+		
+		// a = table PRODUCTS_ATTRIBUTES
+		// p = table PRODUCTS
+		// o = table PRODUCTS_OPTIONS
+		// v = table PRODUCTS_OPTIONS_VALUES
+		// d = table PRODUCTS_ATTRIBUTES_DOWNLOAD
+		// s = table PRODUCTS_WITH_ATTRIBUTES_STOCK
+		// pd = table PRODUCTS_DESCRIPTIONS
+		$filelayout_sql = 'SELECT
+			a.products_attributes_id            as v_products_attributes_id,
+			a.products_id                       as v_products_id,
+			p.products_model				    as v_products_model,
+			a.options_id                        as v_options_id,
+			o.products_options_id               as v_products_options_id,
+			o.products_options_name             as v_products_options_name,
+			o.products_options_type             as v_products_options_type,
+			a.options_values_id                 as v_options_values_id,
+			v.products_options_values_id        as v_products_options_values_id,
+			v.products_options_values_name      as v_products_options_values_name,'./*
+			a.options_values_price              as v_options_values_price,
+			a.price_prefix                      as v_price_prefix,
+			a.products_options_sort_order       as v_products_options_sort_order,
+			a.product_attribute_is_free         as v_product_attribute_is_free,
+			a.products_attributes_weight        as v_products_attributes_weight,
+			a.products_attributes_weight_prefix as v_products_attributes_weight_prefix,
+			a.attributes_display_only           as v_attributes_display_only,
+			a.attributes_default                as v_attributes_default,
+			a.attributes_discounted             as v_attributes_discounted,
+			a.attributes_image                  as v_attributes_image,
+			a.attributes_price_base_included    as v_attributes_price_base_included,
+			a.attributes_price_onetime          as v_attributes_price_onetime,
+			a.attributes_price_factor           as v_attributes_price_factor,
+			a.attributes_price_factor_offset    as v_attributes_price_factor_offset,
+			a.attributes_price_factor_onetime   as v_attributes_price_factor_onetime,
+			a.attributes_price_factor_onetime_offset      as v_attributes_price_factor_onetime_offset,
+			a.attributes_qty_prices             as v_attributes_qty_prices,
+			a.attributes_qty_prices_onetime     as v_attributes_qty_prices_onetime,
+			a.attributes_price_words            as v_attributes_price_words,
+			a.attributes_price_words_free       as v_attributes_price_words_free,
+			a.attributes_price_letters          as v_attributes_price_letters,
+			a.attributes_price_letters_free     as v_attributes_price_letters_free,
+			a.attributes_required               as v_attributes_required, */
+			's.stock_id					 as v_stock_id,
+			s.stock_attributes				 as v_stock_attributes,
+			s.quantity					 as v_quantity,
+			s.sort						 as v_sort,
+			pd.products_name				 as v_products_name
+			FROM '
+			.TABLE_PRODUCTS_ATTRIBUTES.     ' as a,'
+			.TABLE_PRODUCTS.                ' as p,'
+			.TABLE_PRODUCTS_OPTIONS.        ' as o,'
+			.TABLE_PRODUCTS_OPTIONS_VALUES. ' as v,'
+			.TABLE_PRODUCTS_WITH_ATTRIBUTES_STOCK. ' as s,'
+			.TABLE_PRODUCTS_DESCRIPTION.	  ' as pd
+			WHERE
+			a.products_id       = p.products_id AND
+			pd.products_id		= p.products_id AND
+			a.options_id        = o.products_options_id AND
+			a.options_values_id = v.products_options_values_id AND
+			o.language_id       = v.language_id AND
+			o.language_id       = 1 AND
+			s.products_id		= p.products_id AND
+			s.stock_attributes	= a.products_attributes_id
+			ORDER BY a.products_id, a.options_id, v.products_options_values_id';
+ 		break;
+
 		
 	case 'options':
 		$filelayout[] =	'v_products_options_id';


### PR DESCRIPTION
...s

that already are being tracked by SBA.  Also incorporated the correction
for Basic Attribute export so that the products option types would be
correct.  Shows user readable information for items that have only one option type. (I.e., color); however, if there is more than one option type, then verbiage will not yet download properly, but quantities will be correctly updated on import.
Option to use SBA is dependent on the existence of the PRODUCTS WITH ATTRIBUTES STOCK  table, that the table has only 5 columns, and that the columns are titled: stock_id, product_id, stock_attributes, quantity, and sort.  If this is not the case, then can not export nor import on this option.  If you have the ability to stock by attributes, but do not have this option, then may need more information made available to incorporate the functionality.  (I.e., the table(s) associated, the field names, a download location for the plugin that provided this functionality for your Zen-Cart, etc.)
