### PR TITLE
Correct usage of bindVars for attributes

### DIFF
--- a/admin/easypopulate_4_attrib.php
+++ b/admin/easypopulate_4_attrib.php
@@ -22,7 +22,7 @@ while ($contents = fgetcsv($handle, 0, $csv_delimiter, $csv_enclosure)) { // whi
 	// READ products_id and products_model from TABLE_PRODUCTS
 	// Since products_model must be unique (for EP4 at least), this query can be LIMIT 1 
 	$query ="SELECT * FROM ".TABLE_PRODUCTS." WHERE (products_model = :v_products_model:) LIMIT 1";
-	$query = $db->bindVars($query, ':v_products_model', $v_products_model, 'string');
+	$query = $db->bindVars($query, ':v_products_model:', $v_products_model, 'string');
 	$result = ep_4_query($query);
 
 	if (($ep_uses_mysqli ? mysqli_num_rows($result) : mysql_num_rows($result)) == 0)  { // products_model is not in TABLE_PRODUCTS
@@ -94,8 +94,8 @@ while ($contents = fgetcsv($handle, 0, $csv_delimiter, $csv_enclosure)) { // whi
 						(:v_products_options_id:, :language_id:, :v_products_options_name:, :v_products_options_type:)";
 					$sql = $db->bindVars($sql, ':v_products_options_id:', $v_products_options_id, 'integer');
 					$sql = $db->bindVars($sql, ':language_id:', $l_id, 'integer');
-					$sql = $db->bindVars($sql, ':v_products_options_name', $v_products_options_name[$l_id], 'string');
-					$sql = $db->bindVars($sql, ':v_products_options_type', $v_products_options_type, 'integer');
+					$sql = $db->bindVars($sql, ':v_products_options_name:', $v_products_options_name[$l_id], 'string');
+					$sql = $db->bindVars($sql, ':v_products_options_type:', $v_products_options_type, 'integer');
 					$errorcheck = ep_4_query($sql);
 				}
 				$new_options_name++;


### PR DESCRIPTION
In four locations the use of bindVars was not correctly implemented. In each case the sql statement had a variable formatted like ':var:' but in the substitution performed by bindVars the variable was identified as only ':var' this causes an extra : to remain behind in the sql. 

This method of substitution has been chosen to prevent incorrect substitution from occurring because of incorrect sequencing of the bindVars functions when more than one variable begins with the same text as one that is fully defined by that beginning text. Ie. :value substituted into :value_me will cause an issue if :value_me isn't listed before :value in the bindVars sequencing.  Generally speaking ZC table fields are unique throughout at least on non-linking fields and therefore the occurrence of something like this is low, but it does appear to be a safe programming standard to minimize the occurrence of "unknown/unexpected" results.
