### PR TITLE
Changing products_type search to search for name of handler

### DIFF
--- a/admin/easypopulate_4_import.php
+++ b/admin/easypopulate_4_import.php
@@ -1149,9 +1149,9 @@ if (!(isset($_POST['import']) && $_POST['import'] != '')) {
             }
             if (!isset($filelayout['v_products_type'])) {
               if ($v_artists_name <> '') {
-                $v_products_type = 2; // 2 = music Product - Music
+                $v_products_type = 'product_music'; // Change products_type to handler instead of numbers -- retched
               } elseif (empty($v_products_type) && $product_is_new) {
-                $v_products_type = 1; // 1 = standard product @TODO Allow import of alternate product type
+                $v_products_type = 'product'; // Change products_type to handler instead of numbers -- retched
               }
             }
 
@@ -1230,7 +1230,7 @@ if (!(isset($_POST['import']) && $_POST['import'] != '')) {
               metatags_price_status     = :metatags_price_status:,
               metatags_title_tagline_status = :metatags_title_tagline_status:";
             $query = $db->bindVars($query, ':products_model:', $v_products_model , $zc_support_ignore_null);
-            $query = $db->bindVars($query, ':products_type:', $v_products_type , 'integer');
+            $query = $db->bindVars($query, ':products_type:', ep4_get_product_type_handle($v_products_type) , 'integer'); // Change products_type to handler instead of numbers -- retched
             $query = $db->bindVars($query, ':products_price:', $v_products_price , 'currency');
             $query = $db->bindVars($query, ':products_price_uom:', (isset($v_products_price_uom) ? $v_products_price_uom : '0.00') , 'currency');
             $query = $db->bindVars($query, ':products_id:', $v_products_id, 'integer');
@@ -1283,7 +1283,7 @@ if (!(isset($_POST['import']) && $_POST['import'] != '')) {
             }
             $ep_import_count++;
             // PRODUCT_MUSIC_EXTRA
-            if ($v_products_type == '2') {
+            if ($v_products_type == 'product_music') { // Change products_type to handler instead of numbers -- retched
               $sql_music_extra = "SELECT * FROM " . TABLE_PRODUCT_MUSIC_EXTRA . " WHERE (products_id = :products_id:) LIMIT 1";
               $sql_music_extra = $db->bindVars($sql_music_extra, ':products_id:', $v_products_id, 'integer');
               $sql_music_extra = ep_4_query($sql_music_extra);
@@ -1448,7 +1448,7 @@ if (!(isset($_POST['import']) && $_POST['import'] != '')) {
                 unset($summary);
               }
               // PRODUCT_MUSIC_EXTRA
-              if ($v_products_type == '2') {
+              if ($v_products_type == 'product_music') { // Change products_type to handler instead of numbers -- retched
                 $sql_music_extra = ep_4_query("SELECT * FROM " . TABLE_PRODUCT_MUSIC_EXTRA . " WHERE (products_id = " . (int)$v_products_id . ") LIMIT 1");
                 if ($ep_4_num_rows($sql_music_extra) == 1) { // update
                   $query = "UPDATE " . TABLE_PRODUCT_MUSIC_EXTRA . " SET

--- a/admin/includes/functions/extra_functions/easypopulate_4_functions.php
+++ b/admin/includes/functions/extra_functions/easypopulate_4_functions.php
@@ -1351,3 +1351,16 @@ function ep4_draw_cat_list($current_cat_id, $withAttribs = true, $withProd = tru
     }
     return '';
 }
+
+
+function ep4_get_product_type_handle($str_handle) {
+  global $db;
+// This function will change the text handle to a numeric one for insert.
+// Will return 1 by default if it fails to find the type handler
+
+  $sql = "SELECT type_id FROM " . TABLE_PRODUCT_TYPES . " WHERE type_handler = :type_handler:";
+  $sql = $db->bindVars($sql, ':type_handler:', $str_handle , 'string');
+  $handler = $db->Execute($sql);
+
+return $handler->fields['type_id'] ?? 1;
+}

--- a/admin/includes/modules/easypopulate_4_filelayout.php
+++ b/admin/includes/modules/easypopulate_4_filelayout.php
@@ -294,11 +294,12 @@ if (!defined('EASYPOPULATE_4_CONFIG_LANGUAGE_EXPORT')) {
       unset($l_id_code);
       $filelayout[] = 'v_music_genre_name';
     }
+    // Change products_type to handler instead of numbers -- retched
     $filelayout_sql = 'SELECT DISTINCT
 
-      p.products_id         as v_products_id,
+      p.products_id           as v_products_id,
       p.products_model        as v_products_model,
-      p.products_type         as v_products_type,
+      pt.type_handler         as v_products_type,
       p.products_image        as v_products_image,
       p.products_price        as v_products_price,';
     if ($ep_supported_mods['uom'] == true) { // price UOM mod
@@ -369,6 +370,10 @@ if (!defined('EASYPOPULATE_4_CONFIG_LANGUAGE_EXPORT')) {
       LEFT JOIN ' . TABLE_MANUFACTURERS_INFO .' AS mi
         ON (
           p.manufacturers_id = mi.manufacturers_id
+        )
+      LEFT JOIN ' . TABLE_PRODUCT_TYPES . ' AS pt
+        ON (
+          pt.type_id = p.products_type
         )
       ';
       


### PR DESCRIPTION
Currently the v_products_type field does a search by the product's type_id as defined in the products table. This code will change it so that instead of looking for the product's `type_id`, it will search for the product's `type_handler`. If the search fails, it will assume the default product type of 1.